### PR TITLE
User agent for Android

### DIFF
--- a/Resources/analytics.js
+++ b/Resources/analytics.js
@@ -103,6 +103,9 @@ var Analytics = AnalyticsBase.extend({
 	
 	//Constructor: var analytics = new Analytics('UA-XXXXXXX-X');
 	init: function(accountId){
+		if(Ti.Platform.osname === 'android') {
+			this._USER_AGENT = 'GoogleAnalytics/1.0 (Linux; U; Android ' + Titanium.Platform.version + '; ' + Titanium.Locale.currentLocale + '; ' + Titanium.Platform.model + ')';
+		}
 		this._accountId = accountId;
 		this._db = Titanium.Database.open('analytics');
 		this._initialize_db();


### PR DESCRIPTION
Added support for an Android user agent string. I haven't used the Titanium.Locale.getCurrentCountry() function (used Titanium.Locale.currentLocale instead), but feel free to change it.

In Google Analytics, for both iPhone and Android the language shows up as xx-XX-undefined. I don't know why.
